### PR TITLE
Add EventEmitters to outputs, fixing 'Cannot read property 'subscribe…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter } from '@angular/core';
 
 /**
  * Examples:
@@ -18,5 +18,11 @@ export function MockComponent(options: Component): Component {
     outputs: options.outputs
   };
 
-  return Component(metadata)(class _ {});
+  class Mock {}
+
+  options.outputs.forEach((method) => {
+    Mock.prototype[method] = new EventEmitter<Object>();
+  });
+
+  return Component(metadata)(Mock);
 }

--- a/index.ts
+++ b/index.ts
@@ -15,12 +15,12 @@ export function MockComponent(options: Component): Component {
     selector: options.selector,
     template: options.template || '',
     inputs: options.inputs,
-    outputs: options.outputs
+    outputs: options.outputs || []
   };
 
   class Mock {}
 
-  options.outputs.forEach((method) => {
+  metadata.outputs.forEach((method) => {
     Mock.prototype[method] = new EventEmitter<Object>();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "module": "commonjs",
     "target": "ES5",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
…' of undefined'.

When mocking a component with a event binding, for instance (click)="...", I get the following error. Adding the EventEmitter's fixes this.

```TypeError: Cannot read property 'subscribe' of undefined```