### PR TITLE
Minor code style fixes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import { Component, EventEmitter } from '@angular/core';
 
 export function MockComponent(options: Component): Component {
 
-  let metadata: Component = {
+  const metadata: Component = {
     selector: options.selector,
     template: options.template || '',
     inputs: options.inputs,
@@ -20,7 +20,7 @@ export function MockComponent(options: Component): Component {
 
   class Mock {}
 
-  metadata.outputs.forEach((method) => {
+  metadata.outputs.forEach(method => {
     Mock.prototype[method] = new EventEmitter<any>();
   });
 


### PR DESCRIPTION
I've added minor code style fixes:
1. Set const instead let as we won't re-assign metadata value.
2. Remove unnecessary parentheses.