### PR TITLE
Bugfix: Do not share/set output events on Mock.prototype

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,11 +19,13 @@ export function MockComponent(options: Component): Component {
     exportAs: options.exportAs || ''
   };
 
-  class Mock {}
-
-  metadata.outputs.forEach(method => {
-    Mock.prototype[method] = new EventEmitter<any>();
-  });
+  class Mock {
+    constructor() {
+      metadata.outputs.forEach(method => {
+        this[method] = new EventEmitter<any>();
+      });
+    }
+  }
 
   return Component(metadata)(Mock as any);
 }


### PR DESCRIPTION
## What this PR does

This fixes a bug where output event emitters were being shared. Setting the output EventEmitter property on the prototype means that the last value set will be used by all instances of the Mock class. This is likely not the intended behavior and it means you cannot test output events for multiple component instances.

Moving this to inside the Mock constructor ensures that every mock instance gets its own EventEmitter.