### PR TITLE
Support component options including providers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,14 +10,10 @@ import { Component, EventEmitter } from '@angular/core';
  */
 
 export function MockComponent(options: Component): Component {
-
-  const metadata: Component = {
-    selector: options.selector,
-    template: options.template || '',
-    inputs: options.inputs,
-    outputs: options.outputs || [],
-    exportAs: options.exportAs || ''
-  };
+  const metadata = {...options};
+  metadata.template = metadata.template || '';
+  metadata.outputs = metadata.outputs || [];
+  metadata.exportAs = metadata.exportAs || '';
 
   class Mock {}
 


### PR DESCRIPTION
It is not possible to mock a component with providers. This is useful for a component that is a `controlValueAccessor`.

Now it's possible to mock a component that is a form input by specifying providers.

```typescript
MockComponent({
selector: 'foo',
providers: [{
  provide: NG_VALUE_ACCESSOR,
  useValue: {/**provider implementation**/}
  multi: true
}]
})
```

This PR also takes care of any other scenarios where component properties are to be specified.